### PR TITLE
Revert "Acpica trivial"

### DIFF
--- a/source/common/dmtbdump.c
+++ b/source/common/dmtbdump.c
@@ -2450,7 +2450,7 @@ AcpiDmDumpMcfg (
     {
         if (Offset + sizeof (ACPI_MCFG_ALLOCATION) > Table->Length)
         {
-            AcpiOsPrintf ("Warning: there are %lu invalid trailing bytes\n",
+            AcpiOsPrintf ("Warning: there are %u invalid trailing bytes\n",
                 sizeof (ACPI_MCFG_ALLOCATION) - (Offset - Table->Length));
             return;
         }

--- a/source/compiler/aslascii.c
+++ b/source/compiler/aslascii.c
@@ -252,8 +252,8 @@ FlIsFileAsciiSource (
         if (DisplayErrors)
         {
             AcpiOsPrintf (
-                "Total %lu invalid characters found in input source text, "
-                "could be a binary file\n", (UINT64) BadBytes);
+                "Total %u invalid characters found in input source text, "
+                "could be a binary file\n", BadBytes);
             AslError (ASL_ERROR, ASL_MSG_NON_ASCII, NULL, Filename);
         }
 

--- a/source/components/debugger/dbhistry.c
+++ b/source/components/debugger/dbhistry.c
@@ -248,7 +248,7 @@ AcpiDbDisplayHistory (
     {
         if (AcpiGbl_HistoryBuffer[HistoryIndex].Command)
         {
-            AcpiOsPrintf ("%3u  %s\n",
+            AcpiOsPrintf ("%3ld  %s\n",
                 AcpiGbl_HistoryBuffer[HistoryIndex].CmdNum,
                 AcpiGbl_HistoryBuffer[HistoryIndex].Command);
         }

--- a/source/components/debugger/dbinput.c
+++ b/source/components/debugger/dbinput.c
@@ -731,7 +731,7 @@ AcpiDbGetLine (
         InputBuffer))
     {
         AcpiOsPrintf (
-            "Buffer overflow while parsing input line (max %lu characters)\n",
+            "Buffer overflow while parsing input line (max %u characters)\n",
             sizeof (AcpiGbl_DbParsedBuf));
         return (0);
     }
@@ -1003,10 +1003,10 @@ AcpiDbCommandDispatch (
         if (ParamCount == 0)
         {
             AcpiOsPrintf (
-                "Current debug level for file output is:    %8.8X\n",
+                "Current debug level for file output is:    %8.8lX\n",
                 AcpiGbl_DbDebugLevel);
             AcpiOsPrintf (
-                "Current debug level for console output is: %8.8X\n",
+                "Current debug level for console output is: %8.8lX\n",
                 AcpiGbl_DbConsoleDebugLevel);
         }
         else if (ParamCount == 2)
@@ -1015,7 +1015,7 @@ AcpiDbCommandDispatch (
             AcpiGbl_DbConsoleDebugLevel =
                 strtoul (AcpiGbl_DbArgs[1], NULL, 16);
             AcpiOsPrintf (
-                "Debug Level for console output was %8.8X, now %8.8X\n",
+                "Debug Level for console output was %8.8lX, now %8.8lX\n",
                 Temp, AcpiGbl_DbConsoleDebugLevel);
         }
         else
@@ -1023,7 +1023,7 @@ AcpiDbCommandDispatch (
             Temp = AcpiGbl_DbDebugLevel;
             AcpiGbl_DbDebugLevel = strtoul (AcpiGbl_DbArgs[1], NULL, 16);
             AcpiOsPrintf (
-                "Debug Level for file output was %8.8X, now %8.8X\n",
+                "Debug Level for file output was %8.8lX, now %8.8lX\n",
                 Temp, AcpiGbl_DbDebugLevel);
         }
         break;

--- a/source/components/debugger/dbstats.c
+++ b/source/components/debugger/dbstats.c
@@ -508,14 +508,14 @@ AcpiDbDisplayStatistics (
 
         for (i = 0; i < ACPI_TYPE_NS_NODE_MAX; i++)
         {
-            AcpiOsPrintf ("%16.16s % 10d% 10d\n", AcpiUtGetTypeName (i),
+            AcpiOsPrintf ("%16.16s % 10ld% 10ld\n", AcpiUtGetTypeName (i),
                 AcpiGbl_NodeTypeCount [i], AcpiGbl_ObjTypeCount [i]);
         }
 
-        AcpiOsPrintf ("%16.16s % 10d% 10d\n", "Misc/Unknown",
+        AcpiOsPrintf ("%16.16s % 10ld% 10ld\n", "Misc/Unknown",
             AcpiGbl_NodeTypeCountMisc, AcpiGbl_ObjTypeCountMisc);
 
-        AcpiOsPrintf ("%16.16s % 10d% 10d\n", "TOTALS:",
+        AcpiOsPrintf ("%16.16s % 10ld% 10ld\n", "TOTALS:",
             AcpiGbl_NumNodes, AcpiGbl_NumObjects);
         break;
 
@@ -541,9 +541,9 @@ AcpiDbDisplayStatistics (
     case CMD_STAT_MISC:
 
         AcpiOsPrintf ("\nMiscellaneous Statistics:\n\n");
-        AcpiOsPrintf ("Calls to AcpiPsFind:..  ........% 7d\n",
+        AcpiOsPrintf ("Calls to AcpiPsFind:..  ........% 7ld\n",
             AcpiGbl_PsFindCount);
-        AcpiOsPrintf ("Calls to AcpiNsLookup:..........% 7d\n",
+        AcpiOsPrintf ("Calls to AcpiNsLookup:..........% 7ld\n",
             AcpiGbl_NsLookupCount);
 
         AcpiOsPrintf ("\n");
@@ -551,7 +551,7 @@ AcpiDbDisplayStatistics (
         AcpiOsPrintf ("Mutex usage:\n\n");
         for (i = 0; i < ACPI_NUM_MUTEX; i++)
         {
-            AcpiOsPrintf ("%-28s:       % 7d\n",
+            AcpiOsPrintf ("%-28s:       % 7ld\n",
                 AcpiUtGetMutexName (i), AcpiGbl_MutexInfo[i].UseCount);
         }
         break;
@@ -560,50 +560,50 @@ AcpiDbDisplayStatistics (
 
         AcpiOsPrintf ("\nInternal object sizes:\n\n");
 
-        AcpiOsPrintf ("Common           %3ld\n", sizeof (ACPI_OBJECT_COMMON));
-        AcpiOsPrintf ("Number           %3ld\n", sizeof (ACPI_OBJECT_INTEGER));
-        AcpiOsPrintf ("String           %3ld\n", sizeof (ACPI_OBJECT_STRING));
-        AcpiOsPrintf ("Buffer           %3ld\n", sizeof (ACPI_OBJECT_BUFFER));
-        AcpiOsPrintf ("Package          %3ld\n", sizeof (ACPI_OBJECT_PACKAGE));
-        AcpiOsPrintf ("BufferField      %3ld\n", sizeof (ACPI_OBJECT_BUFFER_FIELD));
-        AcpiOsPrintf ("Device           %3ld\n", sizeof (ACPI_OBJECT_DEVICE));
-        AcpiOsPrintf ("Event            %3ld\n", sizeof (ACPI_OBJECT_EVENT));
-        AcpiOsPrintf ("Method           %3ld\n", sizeof (ACPI_OBJECT_METHOD));
-        AcpiOsPrintf ("Mutex            %3ld\n", sizeof (ACPI_OBJECT_MUTEX));
-        AcpiOsPrintf ("Region           %3ld\n", sizeof (ACPI_OBJECT_REGION));
-        AcpiOsPrintf ("PowerResource    %3ld\n", sizeof (ACPI_OBJECT_POWER_RESOURCE));
-        AcpiOsPrintf ("Processor        %3ld\n", sizeof (ACPI_OBJECT_PROCESSOR));
-        AcpiOsPrintf ("ThermalZone      %3ld\n", sizeof (ACPI_OBJECT_THERMAL_ZONE));
-        AcpiOsPrintf ("RegionField      %3ld\n", sizeof (ACPI_OBJECT_REGION_FIELD));
-        AcpiOsPrintf ("BankField        %3ld\n", sizeof (ACPI_OBJECT_BANK_FIELD));
-        AcpiOsPrintf ("IndexField       %3ld\n", sizeof (ACPI_OBJECT_INDEX_FIELD));
-        AcpiOsPrintf ("Reference        %3ld\n", sizeof (ACPI_OBJECT_REFERENCE));
-        AcpiOsPrintf ("Notify           %3ld\n", sizeof (ACPI_OBJECT_NOTIFY_HANDLER));
-        AcpiOsPrintf ("AddressSpace     %3ld\n", sizeof (ACPI_OBJECT_ADDR_HANDLER));
-        AcpiOsPrintf ("Extra            %3ld\n", sizeof (ACPI_OBJECT_EXTRA));
-        AcpiOsPrintf ("Data             %3ld\n", sizeof (ACPI_OBJECT_DATA));
+        AcpiOsPrintf ("Common           %3d\n", sizeof (ACPI_OBJECT_COMMON));
+        AcpiOsPrintf ("Number           %3d\n", sizeof (ACPI_OBJECT_INTEGER));
+        AcpiOsPrintf ("String           %3d\n", sizeof (ACPI_OBJECT_STRING));
+        AcpiOsPrintf ("Buffer           %3d\n", sizeof (ACPI_OBJECT_BUFFER));
+        AcpiOsPrintf ("Package          %3d\n", sizeof (ACPI_OBJECT_PACKAGE));
+        AcpiOsPrintf ("BufferField      %3d\n", sizeof (ACPI_OBJECT_BUFFER_FIELD));
+        AcpiOsPrintf ("Device           %3d\n", sizeof (ACPI_OBJECT_DEVICE));
+        AcpiOsPrintf ("Event            %3d\n", sizeof (ACPI_OBJECT_EVENT));
+        AcpiOsPrintf ("Method           %3d\n", sizeof (ACPI_OBJECT_METHOD));
+        AcpiOsPrintf ("Mutex            %3d\n", sizeof (ACPI_OBJECT_MUTEX));
+        AcpiOsPrintf ("Region           %3d\n", sizeof (ACPI_OBJECT_REGION));
+        AcpiOsPrintf ("PowerResource    %3d\n", sizeof (ACPI_OBJECT_POWER_RESOURCE));
+        AcpiOsPrintf ("Processor        %3d\n", sizeof (ACPI_OBJECT_PROCESSOR));
+        AcpiOsPrintf ("ThermalZone      %3d\n", sizeof (ACPI_OBJECT_THERMAL_ZONE));
+        AcpiOsPrintf ("RegionField      %3d\n", sizeof (ACPI_OBJECT_REGION_FIELD));
+        AcpiOsPrintf ("BankField        %3d\n", sizeof (ACPI_OBJECT_BANK_FIELD));
+        AcpiOsPrintf ("IndexField       %3d\n", sizeof (ACPI_OBJECT_INDEX_FIELD));
+        AcpiOsPrintf ("Reference        %3d\n", sizeof (ACPI_OBJECT_REFERENCE));
+        AcpiOsPrintf ("Notify           %3d\n", sizeof (ACPI_OBJECT_NOTIFY_HANDLER));
+        AcpiOsPrintf ("AddressSpace     %3d\n", sizeof (ACPI_OBJECT_ADDR_HANDLER));
+        AcpiOsPrintf ("Extra            %3d\n", sizeof (ACPI_OBJECT_EXTRA));
+        AcpiOsPrintf ("Data             %3d\n", sizeof (ACPI_OBJECT_DATA));
 
         AcpiOsPrintf ("\n");
 
-        AcpiOsPrintf ("ParseObject      %3ld\n", sizeof (ACPI_PARSE_OBJ_COMMON));
-        AcpiOsPrintf ("ParseObjectNamed %3ld\n", sizeof (ACPI_PARSE_OBJ_NAMED));
-        AcpiOsPrintf ("ParseObjectAsl   %3ld\n", sizeof (ACPI_PARSE_OBJ_ASL));
-        AcpiOsPrintf ("OperandObject    %3ld\n", sizeof (ACPI_OPERAND_OBJECT));
-        AcpiOsPrintf ("NamespaceNode    %3ld\n", sizeof (ACPI_NAMESPACE_NODE));
-        AcpiOsPrintf ("AcpiObject       %3ld\n", sizeof (ACPI_OBJECT));
+        AcpiOsPrintf ("ParseObject      %3d\n", sizeof (ACPI_PARSE_OBJ_COMMON));
+        AcpiOsPrintf ("ParseObjectNamed %3d\n", sizeof (ACPI_PARSE_OBJ_NAMED));
+        AcpiOsPrintf ("ParseObjectAsl   %3d\n", sizeof (ACPI_PARSE_OBJ_ASL));
+        AcpiOsPrintf ("OperandObject    %3d\n", sizeof (ACPI_OPERAND_OBJECT));
+        AcpiOsPrintf ("NamespaceNode    %3d\n", sizeof (ACPI_NAMESPACE_NODE));
+        AcpiOsPrintf ("AcpiObject       %3d\n", sizeof (ACPI_OBJECT));
 
         AcpiOsPrintf ("\n");
 
-        AcpiOsPrintf ("Generic State    %3ld\n", sizeof (ACPI_GENERIC_STATE));
-        AcpiOsPrintf ("Common State     %3ld\n", sizeof (ACPI_COMMON_STATE));
-        AcpiOsPrintf ("Control State    %3ld\n", sizeof (ACPI_CONTROL_STATE));
-        AcpiOsPrintf ("Update State     %3ld\n", sizeof (ACPI_UPDATE_STATE));
-        AcpiOsPrintf ("Scope State      %3ld\n", sizeof (ACPI_SCOPE_STATE));
-        AcpiOsPrintf ("Parse Scope      %3ld\n", sizeof (ACPI_PSCOPE_STATE));
-        AcpiOsPrintf ("Package State    %3ld\n", sizeof (ACPI_PKG_STATE));
-        AcpiOsPrintf ("Thread State     %3ld\n", sizeof (ACPI_THREAD_STATE));
-        AcpiOsPrintf ("Result Values    %3ld\n", sizeof (ACPI_RESULT_VALUES));
-        AcpiOsPrintf ("Notify Info      %3ld\n", sizeof (ACPI_NOTIFY_INFO));
+        AcpiOsPrintf ("Generic State    %3d\n", sizeof (ACPI_GENERIC_STATE));
+        AcpiOsPrintf ("Common State     %3d\n", sizeof (ACPI_COMMON_STATE));
+        AcpiOsPrintf ("Control State    %3d\n", sizeof (ACPI_CONTROL_STATE));
+        AcpiOsPrintf ("Update State     %3d\n", sizeof (ACPI_UPDATE_STATE));
+        AcpiOsPrintf ("Scope State      %3d\n", sizeof (ACPI_SCOPE_STATE));
+        AcpiOsPrintf ("Parse Scope      %3d\n", sizeof (ACPI_PSCOPE_STATE));
+        AcpiOsPrintf ("Package State    %3d\n", sizeof (ACPI_PKG_STATE));
+        AcpiOsPrintf ("Thread State     %3d\n", sizeof (ACPI_THREAD_STATE));
+        AcpiOsPrintf ("Result Values    %3d\n", sizeof (ACPI_RESULT_VALUES));
+        AcpiOsPrintf ("Notify Info      %3d\n", sizeof (ACPI_NOTIFY_INFO));
         break;
 
     case CMD_STAT_STACK:

--- a/source/components/tables/tbxfload.c
+++ b/source/components/tables/tbxfload.c
@@ -348,6 +348,11 @@ AcpiTbLoadNamespace (
         Status = AE_CTRL_TERMINATE;
     }
 
+#ifdef ACPI_APPLICATION
+    ACPI_DEBUG_PRINT_RAW ((ACPI_DB_INIT, "\n"));
+#endif
+
+
 UnlockAndExit:
     (void) AcpiUtReleaseMutex (ACPI_MTX_TABLES);
     return_ACPI_STATUS (Status);

--- a/source/components/utilities/utdebug.c
+++ b/source/components/utilities/utdebug.c
@@ -284,7 +284,7 @@ AcpiDebugPrint (
      * Display the module name, current line number, thread ID (if requested),
      * current procedure nesting level, and the current procedure name
      */
-    AcpiOsPrintf ("%9s-%04d ", ModuleName, LineNumber);
+    AcpiOsPrintf ("%9s-%04ld ", ModuleName, LineNumber);
 
 #ifdef ACPI_APPLICATION
     /*
@@ -298,7 +298,7 @@ AcpiDebugPrint (
         AcpiOsPrintf ("[%u] ", (UINT32) ThreadId);
     }
 
-    AcpiOsPrintf ("[%02d] ", AcpiGbl_NestingLevel);
+    AcpiOsPrintf ("[%02ld] ", AcpiGbl_NestingLevel);
 #endif
 
     AcpiOsPrintf ("%-22.22s: ", AcpiUtTrimFunctionName (FunctionName));

--- a/source/include/acmacros.h
+++ b/source/include/acmacros.h
@@ -531,13 +531,8 @@
  * the plist contains a set of parens to allow variable-length lists.
  * These macros are used for both the debug and non-debug versions of the code.
  */
-#if defined (ACPI_USE_DO_ONCE_MACRO) && defined (ACPI_DO_ONCE)
-#define ACPI_ERROR_NAMESPACE(s, e)          ACPI_DO_ONCE(AcpiUtNamespaceError (AE_INFO, s, e));
-#define ACPI_ERROR_METHOD(s, n, p, e)       ACPI_DO_ONCE(AcpiUtMethodError (AE_INFO, s, n, p, e));
-#else
 #define ACPI_ERROR_NAMESPACE(s, e)          AcpiUtNamespaceError (AE_INFO, s, e);
 #define ACPI_ERROR_METHOD(s, n, p, e)       AcpiUtMethodError (AE_INFO, s, n, p, e);
-#endif
 #define ACPI_WARN_PREDEFINED(plist)         AcpiUtPredefinedWarning plist
 #define ACPI_INFO_PREDEFINED(plist)         AcpiUtPredefinedInfo plist
 #define ACPI_BIOS_ERROR_PREDEFINED(plist)   AcpiUtPredefinedBiosError plist

--- a/source/include/acoutput.h
+++ b/source/include/acoutput.h
@@ -302,17 +302,10 @@
  * the plist contains a set of parens to allow variable-length lists.
  * These macros are used for both the debug and non-debug versions of the code.
  */
-#if defined (ACPI_USE_DO_ONCE_MACRO) && defined (ACPI_DO_ONCE)
-#define ACPI_INFO(plist)                ACPI_DO_ONCE(AcpiInfo plist)
-#define ACPI_WARNING(plist)             ACPI_DO_ONCE(AcpiWarning plist)
-#define ACPI_EXCEPTION(plist)           ACPI_DO_ONCE(AcpiException plist)
-#define ACPI_ERROR(plist)               ACPI_DO_ONCE(AcpiError plist)
-#else
 #define ACPI_INFO(plist)                AcpiInfo plist
 #define ACPI_WARNING(plist)             AcpiWarning plist
 #define ACPI_EXCEPTION(plist)           AcpiException plist
 #define ACPI_ERROR(plist)               AcpiError plist
-#endif
 #define ACPI_BIOS_WARNING(plist)        AcpiBiosWarning plist
 #define ACPI_BIOS_ERROR(plist)          AcpiBiosError plist
 #define ACPI_DEBUG_OBJECT(obj,l,i)      AcpiExDoDebugObject(obj,l,i)

--- a/source/include/acpiosxf.h
+++ b/source/include/acpiosxf.h
@@ -541,7 +541,6 @@ AcpiOsEnterSleep (
  * Debug print routines
  */
 #ifndef ACPI_USE_ALTERNATE_PROTOTYPE_AcpiOsPrintf
-ACPI_PRINTF_LIKE(1)
 void ACPI_INTERNAL_VAR_XFACE
 AcpiOsPrintf (
     const char              *Format,

--- a/source/include/acpixf.h
+++ b/source/include/acpixf.h
@@ -248,14 +248,6 @@ ACPI_INIT_GLOBAL (UINT8,            AcpiGbl_VerifyTableChecksum, TRUE);
 ACPI_INIT_GLOBAL (UINT8,            AcpiGbl_EnableAmlDebugObject, FALSE);
 
 /*
- * Optionally enable ACPI_DO_ONCE to avoid log flodding. Default is TRUE
- * so that when ACPI_USE_DO_ONCE_MACRO is enabled, log flooding can be
- * avoided by default. And this option is provided so that OSPMs can
- * disable it during runtime.
- */
-ACPI_INIT_GLOBAL (UINT8,            AcpiGbl_EnableDoOnceMacro, TRUE);
-
-/*
  * Optionally copy the entire DSDT to local memory (instead of simply
  * mapping it.) There are some BIOSs that corrupt or replace the original
  * DSDT, creating the need for this option. Default is FALSE, do not copy

--- a/source/include/platform/acgcc.h
+++ b/source/include/platform/acgcc.h
@@ -146,19 +146,4 @@
 
 #define COMPILER_VA_MACRO               1
 
-/* GCC supports _ONCE macros */
-
-#define ACPI_DO_ONCE(plist)                             \
-({                                                      \
-    static BOOLEAN          __AcpiErrorOnce__ = FALSE;  \
-    if (!__AcpiErrorOnce__)                             \
-    {                                                   \
-        if (AcpiGbl_EnableDoOnceMacro)                  \
-        {                                               \
-            __AcpiErrorOnce__ = TRUE;                   \
-        }                                               \
-        plist;                                          \
-    }                                                   \
-})
-
 #endif /* __ACGCC_H__ */

--- a/source/include/platform/aclinux.h
+++ b/source/include/platform/aclinux.h
@@ -146,10 +146,6 @@
 #define ACPI_DEBUGGER
 #endif
 
-#ifdef CONFIG_ACPI_MESSAGE_ONCE
-#define ACPI_USE_DO_ONCE_MACRO 1
-#endif
-
 #include <linux/string.h>
 #include <linux/kernel.h>
 #include <linux/ctype.h>

--- a/source/tools/acpiexec/aeexec.c
+++ b/source/tools/acpiexec/aeexec.c
@@ -448,8 +448,8 @@ ExecuteOSI (
     if (ReturnValue.Length < sizeof (ACPI_OBJECT))
     {
         AcpiOsPrintf (
-            "Return value from _OSI method too small, %.8lX\n",
-            (UINT64) ReturnValue.Length);
+            "Return value from _OSI method too small, %.8X\n",
+            ReturnValue.Length);
         goto ErrorExit;
     }
 

--- a/source/tools/acpiexec/aeregion.c
+++ b/source/tools/acpiexec/aeregion.c
@@ -650,12 +650,12 @@ AeRegionHandler (
         if (AcpiGbl_DisplayRegionAccess)
         {
             AcpiOsPrintf ("AcpiExec: %s "
-                "%s: Attr %X Addr %.4X BaseAddr %.4X Len %.2lX Width %X BufLen %X",
+                "%s: Attr %X Addr %.4X BaseAddr %.4X Len %.2X Width %X BufLen %X",
                 AcpiUtGetRegionName (SpaceId),
                 (Function & ACPI_IO_MASK) ? "Write" : "Read ",
                 (UINT32) (Function >> 16),
                 (UINT32) Address, (UINT32) BaseAddress,
-                (UINT64) Length, BitWidth, Buffer[1]);
+                Length, BitWidth, Buffer[1]);
 
             /* GenericSerialBus has a Connection() parameter */
 
@@ -687,10 +687,10 @@ AeRegionHandler (
         if (AcpiGbl_DisplayRegionAccess)
         {
             AcpiOsPrintf ("AcpiExec: IPMI "
-                "%s: Attr %X Addr %.4X BaseAddr %.4X Len %.2lX Width %X BufLen %X\n",
+                "%s: Attr %X Addr %.4X BaseAddr %.4X Len %.2X Width %X BufLen %X\n",
                 (Function & ACPI_IO_MASK) ? "Write" : "Read ",
                 (UINT32) (Function >> 16), (UINT32) Address, (UINT32) BaseAddress,
-                (UINT64) Length, BitWidth, Buffer[1]);
+                Length, BitWidth, Buffer[1]);
         }
 
         /*
@@ -967,9 +967,9 @@ DoFunction:
         case ACPI_ADR_SPACE_SYSTEM_MEMORY:
 
             AcpiOsPrintf ("AcpiExec: SystemMemory "
-                "%s: Val %.8X Addr %.4X Width %X [REGION: BaseAddr %.4X Len %.2lX]\n",
+                "%s: Val %.8X Addr %.4X Width %X [REGION: BaseAddr %.4X Len %.2X]\n",
                 (Function & ACPI_IO_MASK) ? "Write" : "Read ",
-                (UINT32) *Value, (UINT32) Address, BitWidth, (UINT32) BaseAddress, (UINT64) Length);
+                (UINT32) *Value, (UINT32) Address, BitWidth, (UINT32) BaseAddress, Length);
             break;
 
         case ACPI_ADR_SPACE_GPIO:   /* ACPI 5.0 */
@@ -980,9 +980,9 @@ DoFunction:
                 MyContext->Length, &Resource);
 
             AcpiOsPrintf ("AcpiExec: GeneralPurposeIo "
-                "%s: Val %.8X Addr %.4X BaseAddr %.4X Len %.2lX Width %X AccLen %.2X Conn %p\n",
+                "%s: Val %.8X Addr %.4X BaseAddr %.4X Len %.2X Width %X AccLen %.2X Conn %p\n",
                 (Function & ACPI_IO_MASK) ? "Write" : "Read ", (UINT32) *Value,
-                (UINT32) Address, (UINT32) BaseAddress, (UINT64) Length, BitWidth,
+                (UINT32) Address, (UINT32) BaseAddress, Length, BitWidth,
                 MyContext->AccessLength, MyContext->Connection);
             break;
 

--- a/source/tools/acpiexec/aetables.c
+++ b/source/tools/acpiexec/aetables.c
@@ -623,11 +623,8 @@ AeLoadTables (
     ACPI_STATUS             Status;
 
 
-    ACPI_FUNCTION_NAME (AeLoadTables);
-
     Status = AcpiLoadTables ();
     ACPI_CHECK_OK (AcpiLoadTables, Status);
-    ACPI_DEBUG_PRINT_RAW ((ACPI_DB_INIT, "\n"));
 
     /*
      * Test run-time control method installation. Do it twice to test code

--- a/source/tools/examples/examples.c
+++ b/source/tools/examples/examples.c
@@ -540,8 +540,8 @@ ExecuteOSI (void)
 
     if (ReturnValue.Length < sizeof (ACPI_OBJECT))
     {
-        AcpiOsPrintf ("Return value from _OSI method too small, %.8lX\n",
-            (UINT64) ReturnValue.Length);
+        AcpiOsPrintf ("Return value from _OSI method too small, %.8X\n",
+            ReturnValue.Length);
         goto ErrorExit;
     }
 


### PR DESCRIPTION
Reverts acpica/acpica#196

None of this compiles with:

gcc 4.4.5 under Linux
gcc 5.4.0 under Cygwin

Reverting due to the proximity of the next release of ACPICA, development is closing today.

