### PR TITLE
Add a man page for each tool

### DIFF
--- a/generate/unix/Makefile.config
+++ b/generate/unix/Makefile.config
@@ -42,10 +42,12 @@ CC ?=    gcc
 #
 OBJDIR =     obj
 BINDIR =     bin
+MANDIR =     man
 COMPILEOBJ = $(CC) -c $(CFLAGS) $(OPT_CFLAGS) -o $@ $<
 LINKPROG =   $(CC) $(OBJECTS) -o $(PROG) $(LDFLAGS) $(OPT_LDFLAGS)
 PREFIX ?=    /usr
 INSTALLDIR = $(PREFIX)/bin
+MANINSTALLDIR = $(PREFIX)/share/man/man1
 UNAME_S := $(shell uname -s)
 
 #
@@ -81,7 +83,9 @@ endif
 
 INSTALLPROG = \
 	mkdir -p $(DESTDIR)$(INSTALLDIR); \
-	$(INSTALL) $(INSTALLFLAGS) ../$(BINDIR)/$(PROG) $(DESTDIR)$(INSTALLDIR)/$(PROG)
+	$(INSTALL) $(INSTALLFLAGS) ../$(BINDIR)/$(PROG) $(DESTDIR)$(INSTALLDIR)/$(PROG); \
+	mkdir -p $(DESTDIR)$(MANINSTALLDIR); \
+	$(INSTALL) -m 644 ../$(MANDIR)/$(PROG).1.gz $(DESTDIR)$(MANINSTALLDIR)/$(PROG).1
 
 #
 # Rename a .exe file if necessary
@@ -99,6 +103,15 @@ COPYPROG = \
 	@mkdir -p ../$(BINDIR); \
 	cp -f $(PROG) ../$(BINDIR); \
 	echo "- Copy $(PROG) to $(FINAL_PROG)";
+
+#
+# Copy the man page to the proper directory
+#
+COPYMAN = \
+	@mkdir -p ../$(MANDIR); \
+	echo gzip -c $(MAN) to ../$(MANDIR)/$(MAN).gz; \
+	gzip -c $(MAN) > ../$(MANDIR)/$(MAN).gz; \
+	echo "- Copy $(MAN) to ../$(MANDIR)/$(MAN).gz";
 
 #
 # Main ACPICA source directories

--- a/generate/unix/Makefile.rules
+++ b/generate/unix/Makefile.rules
@@ -9,6 +9,7 @@
 
 $(FINAL_PROG) : $(PROG)
 	$(COPYPROG)
+	$(COPYMAN)
 
 $(PROG) : $(INTERMEDIATES) $(MISC) $(OBJECTS)
 	@echo "- Link" $(PROG)
@@ -20,7 +21,8 @@ $(OBJDIR)/%.o : %.c $(HEADERS) $(ACPICA_HEADERS)
 	@$(COMPILEOBJ)
 
 clean :
-	@rm -f $(PROG) $(PROG).exe $(OBJECTS) $(OBJDIR)/*.o $(INTERMEDIATES) $(MISC)
+	@rm -f $(PROG) $(PROG).exe $(OBJECTS) $(OBJDIR)/*.o $(INTERMEDIATES) $(MISC) $(MANDIR)/*.gz
 
 install :
 	$(INSTALLPROG)
+	$(INSTALLMAN)

--- a/generate/unix/acpibin/Makefile
+++ b/generate/unix/acpibin/Makefile
@@ -13,6 +13,7 @@
 include ../Makefile.config
 FINAL_PROG = ../$(BINDIR)/acpibin
 PROG = $(OBJDIR)/acpibin
+MAN = acpibin.1
 
 #
 # Search paths for source files

--- a/generate/unix/acpibin/acpibin.1
+++ b/generate/unix/acpibin/acpibin.1
@@ -1,0 +1,64 @@
+.\" First parameter, NAME, should be all caps
+.\" Second parameter, SECTION, should be 1-8, maybe w/ subsection
+.\" other parameters are allowed: see man(7), man(1)
+.TH ACPIBIN 1 "January 23, 2013"
+.\" Please adjust this date whenever revising the manpage.
+.\"
+.\" Some roff macros, for reference:
+.\" .nh        disable hyphenation
+.\" .hy        enable hyphenation
+.\" .ad l      left justify
+.\" .ad b      justify to both left and right margins
+.\" .nf        disable filling
+.\" .fi        enable filling
+.\" .br        insert line break
+.\" .sp <n>    insert n+1 empty lines
+.\" for manpage-specific macros, see man(7)
+.SH NAME
+acpibin \- ACPI binary AML file utility
+.SH SYNOPSIS
+.B acpibin
+.RI [ <option> ... ]
+
+.SH DESCRIPTION
+This manual page briefly documents the
+.B acpibin
+command. The option list is taken from the acpibin interactive help.
+.PP
+.\" TeX users may be more comfortable with the \fB<whatever>\fP and
+.\" \fI<whatever>\fP escape sequences to invode bold face and italics, 
+.\" respectively.
+.B acpibin
+is a command provided to perform some basic and common operations on
+AML binary files.
+.PP
+Much more detailed documentation may be found at
+http://www.acpica.org/documentation/.
+
+.SH OPTIONS
+
+.PP
+.TP
+.B \-c <file1> <file2>
+Compare two binary AML files
+.TP
+.B \-d <in> <out>
+Dump AML binary to text file
+.TP
+.B \-e <sig> <in> <out>
+Extract binary AML table from acpidump file
+.TP
+.B \-h <file>
+Display table header for binary AML file
+.TP
+.B \-s <file>
+Update checksum for binary AML file
+.TP
+.B \-t
+Terse mode
+
+.SH AUTHOR
+acpibin was written by Robert Moore <robert.moore@intel.com>.
+.PP
+This manual page was written by Al Stone <ahs3@redhat.com> for the
+Fedora project (but may be used by others).

--- a/generate/unix/acpidump/Makefile
+++ b/generate/unix/acpidump/Makefile
@@ -13,6 +13,7 @@
 include ../Makefile.config
 FINAL_PROG = ../$(BINDIR)/acpidump
 PROG = $(OBJDIR)/acpidump
+MAN = acpidump.1
 
 #
 # Search paths for source files

--- a/generate/unix/acpidump/acpidump.1
+++ b/generate/unix/acpidump/acpidump.1
@@ -1,0 +1,106 @@
+.\" First parameter, NAME, should be all caps
+.\" Second parameter, SECTION, should be 1-8, maybe w/ subsection
+.\" other parameters are allowed: see man(7), man(1)
+.TH ACPIDUMP 1 "July 24, 2013"
+.\" Please adjust this date whenever revising the manpage.
+.\"
+.\" Some roff macros, for reference:
+.\" .nh        disable hyphenation
+.\" .hy        enable hyphenation
+.\" .ad l      left justify
+.\" .ad b      justify to both left and right margins
+.\" .nf        disable filling
+.\" .fi        enable filling
+.\" .br        insert line break
+.\" .sp <n>    insert n+1 empty lines
+.\" for manpage-specific macros, see man(7)
+.SH NAME
+acpidump \- ACPI table dump utility
+.SH SYNOPSIS
+.B acpidump
+.RI [ <option> ... ]
+
+.SH DESCRIPTION
+This manual page briefly documents the
+.B acpidump
+command.  The option list is taken from the interactive help.
+.PP
+The
+.B acpidump
+command extracts the ACPI tables currently in use from the running
+kernel in a form usable for later processing by the
+.B acpixtract
+command.
+.PP
+Invocation of
+.B acpidump
+without parameters will dump all available ACPI tables.  Multiple mixed
+instances of the
+.B \-a
+,
+.B \-f
+, and
+.B \-n
+parameters can be used.
+
+.SH OPTIONS
+.PP
+.TP
+.B \-b
+Dump tables in binary format (versus the default human-readable form)
+
+.PP
+.TP
+.B \-h | \-?
+Display this help message
+
+.PP
+.TP
+.B \-o <file>
+Redirect output to a file.  This file can be used later by
+.B acpixtract
+to examine the contents of the ACPI tables.
+
+.PP
+.TP
+.B \-s
+Print table summaries only.
+
+.PP
+.TP
+.B \-v
+Print the version of this utility.
+
+.PP
+.TP
+.B \-z
+Verbose mode.
+
+.PP
+.TP
+.B \-a <address>
+Get a table from a physical address (must be superuser and you must be
+careful which address you use -- dmesg will typically report the addresses
+for the various tables).
+
+.PP
+.TP
+.B \-f <binary-file>
+Get a table from a binary file (see the
+.B \-b
+option).
+
+.PP
+.TP
+.B \-n <signature>
+Get a table via it's name or signature (e.g., MADT or SSDT).
+
+.SH SEE ALSO
+.B acpixtract(1)
+
+.SH AUTHOR
+acpidump was written by Robert Moore <robert.moore@intel.com> and
+Chao Guan <chao.guan@intel.com>.
+.PP
+This manual page was written by Al Stone <ahs3@redhat.com> for the
+Fedora project (but may be used by others).

--- a/generate/unix/acpiexamples/Makefile
+++ b/generate/unix/acpiexamples/Makefile
@@ -14,6 +14,7 @@
 include ../Makefile.config
 FINAL_PROG = ../$(BINDIR)/acpiexamples
 PROG = $(OBJDIR)/acpiexamples
+MAN = acpiexamples.1
 
 #
 # Search paths for source files

--- a/generate/unix/acpiexamples/acpiexamples.1
+++ b/generate/unix/acpiexamples/acpiexamples.1
@@ -1,0 +1,49 @@
+.\" First parameter, NAME, should be all caps
+.\" Second parameter, SECTION, should be 1-8, maybe w/ subsection
+.\" other parameters are allowed: see man(7), man(1)
+.TH ACPIEXAMPLES 1 "August 8, 2018"
+.\" Please adjust this date whenever revising the manpage.
+.\"
+.\" Some roff macros, for reference:
+.\" .nh        disable hyphenation
+.\" .hy        enable hyphenation
+.\" .ad l      left justify
+.\" .ad b      justify to both left and right margins
+.\" .nf        disable filling
+.\" .fi        enable filling
+.\" .br        insert line break
+.\" .sp <n>    insert n+1 empty lines
+.\" for manpage-specific macros, see man(7)
+.SH NAME
+acpiexamples \- program showing what the code examples actually do
+.SH SYNOPSIS
+.B acpiexamples
+
+.SH DESCRIPTION
+This manual page briefly documents the
+.B acpiexamples
+command. This command has no options available.
+.PP
+.\" TeX users may be more comfortable with the \fB<whatever>\fP and
+.\" \fI<whatever>\fP escape sequences to invode bold face and italics, 
+.\" respectively.
+.B acpiexamples
+prints out the results of various calls using the ACPICA source code,
+showing what happens when the calls are made.  These results are from
+building and running the code provided in the
+/usr/share/doc/acpica-tools/examples directory that illustrate the
+proper sequencing of calls and how to make them.
+.PP
+Much more detailed documentation about ACPICA may be found at
+http://www.acpica.org/documentation/.
+
+.SH OPTIONS
+
+.PP
+None
+
+.SH AUTHOR
+acpiexamples was written by Robert Moore <robert.moore@intel.com>.
+.PP
+This manual page was written by Al Stone <ahs3@redhat.com> for the
+Fedora project (but may be used by others).

--- a/generate/unix/acpiexec/Makefile
+++ b/generate/unix/acpiexec/Makefile
@@ -15,6 +15,7 @@
 include ../Makefile.config
 FINAL_PROG = ../$(BINDIR)/acpiexec
 PROG = $(OBJDIR)/acpiexec
+MAN = acpiexec.1
 
 #
 # Search paths for source files

--- a/generate/unix/acpiexec/acpiexec.1
+++ b/generate/unix/acpiexec/acpiexec.1
@@ -1,0 +1,102 @@
+.\" First parameter, NAME, should be all caps
+.\" Second parameter, SECTION, should be 1-8, maybe w/ subsection
+.\" other parameters are allowed: see man(7), man(1)
+.TH ACPIEXEC 1 "January 23, 2013"
+.\" Please adjust this date whenever revising the manpage.
+.\"
+.\" Some roff macros, for reference:
+.\" .nh        disable hyphenation
+.\" .hy        enable hyphenation
+.\" .ad l      left justify
+.\" .ad b      justify to both left and right margins
+.\" .nf        disable filling
+.\" .fi        enable filling
+.\" .br        insert line break
+.\" .sp <n>    insert n+1 empty lines
+.\" for manpage-specific macros, see man(7)
+.SH NAME
+acpiexec \- ACPI AML execution and debug utility
+.SH SYNOPSIS
+.B acpiexec
+.RI [ <option> ... ]
+.RI <aml-file>
+.B ...
+
+.SH DESCRIPTION
+This manual page briefly documents the
+.B acpiexec
+command. The option list is taken from the acpiexec interactive help.
+.PP
+.\" TeX users may be more comfortable with the \fB<whatever>\fP and
+.\" \fI<whatever>\fP escape sequences to invode bold face and italics, 
+.\" respectively.
+.B acpiexec
+provides a simulated execution environment for AML code so that it
+can be more easily tested and debugged.
+.PP
+Much more detailed documentation may be found at
+http://www.acpica.org/documentation/.
+
+.SH OPTIONS
+
+.PP
+.TP
+.B \-?
+Display the help message
+.TP
+.B \-b "command-line"
+Batch mode command line execution (cmd1;cmd2;...)
+.TP
+.B \-M [<method>]
+Batch mode method execution (Default: MAIN)
+.TP
+.B \-da
+Disable method abort on error
+.TP
+.B \-di
+Disable execution of _STA/_INI methods during init
+.TP
+.B \-do
+Disable Operation Region address simulation
+.TP
+.B \-dr
+Disable repair of method return values
+.TP
+.B \-dt
+Disable allocation tracking (performance)
+.TP
+.B \-ef
+Enable display of final memory statistics
+.TP
+.B \-ei
+Enable additional tests for ACPICA interfaces
+.TP
+.B \-em
+Enable interpreter Serialized mode
+.TP
+.B \-es
+Enable interpreter Slack mode
+.TP
+.B \-et
+Enable debug semaphore timeour
+.TP
+.B \-f <value>
+Operation Region initialization fill value
+.TP
+.B \-r
+Use hardware-reduced FADT V5
+.TP
+.B \-vi
+Verbose initialization output
+.TP
+.B \-vr
+Verbose region handler output
+.TP
+.B \-x <debug-level>
+Debug output level
+
+.SH AUTHOR
+acpiexec was written by Robert Moore <robert.moore@intel.com>.
+.PP
+This manual page was written by Al Stone <ahs3@redhat.com> for the
+Fedora project (but may be used by others).

--- a/generate/unix/acpihelp/Makefile
+++ b/generate/unix/acpihelp/Makefile
@@ -14,6 +14,7 @@
 include ../Makefile.config
 FINAL_PROG = ../$(BINDIR)/acpihelp
 PROG = $(OBJDIR)/acpihelp
+MAN = acpihelp.1
 
 #
 # Search paths for source files

--- a/generate/unix/acpihelp/acpihelp.1
+++ b/generate/unix/acpihelp/acpihelp.1
@@ -1,0 +1,80 @@
+.\" First parameter, NAME, should be all caps
+.\" Second parameter, SECTION, should be 1-8, maybe w/ subsection
+.\" other parameters are allowed: see man(7), man(1)
+.TH ACPIHELP 1 "January 23, 2013"
+.\" Please adjust this date whenever revising the manpage.
+.\"
+.\" Some roff macros, for reference:
+.\" .nh        disable hyphenation
+.\" .hy        enable hyphenation
+.\" .ad l      left justify
+.\" .ad b      justify to both left and right margins
+.\" .nf        disable filling
+.\" .fi        enable filling
+.\" .br        insert line break
+.\" .sp <n>    insert n+1 empty lines
+.\" for manpage-specific macros, see man(7)
+.SH NAME
+acpihelp \- ACPI help utility
+.SH SYNOPSIS
+.B acpihelp
+.RI <option> ...
+.RI [<name-prefix>|<hex-value>]
+
+.SH DESCRIPTION
+This manual page briefly documents the
+.B acpihelp
+command. The option list is taken from the acpihelp interactive help.
+.PP
+.\" TeX users may be more comfortable with the \fB<whatever>\fP and
+.\" \fI<whatever>\fP escape sequences to invode bold face and italics, 
+.\" respectively.
+.B acpihelp
+provides descriptive text for AML and ASL keywords, methods, and opcodes.
+.PP
+Much more detailed documentation may be found at
+http://www.acpica.org/documentation/.
+.PP
+If neither a <name-prefix> or a <hex-value> is provided,
+.B acpihelp
+will do the logical equivalent of a "display all."
+.PP
+A default search (that is, a search with no options) and a <name-prefix>
+can mean two different things: (1) if <name-prefix> does not start with
+an underscore, find ASL operator names, or (2) if <name-prefix> does start
+with an underscore, find ASL predefined method names.
+
+.SH OPTIONS
+
+.PP
+.SS ACPI Names and Symbols
+.TP
+.B \-k [<name-prefix>]
+Find/Display ASL non-operator keyword(s)
+.TP
+.B \-m [<name-prefix>]
+Find/Display AML opcode name(s)
+.TP
+.B \-p [<name-prefix>]
+Find/Display ASL predefined method name(s)
+.TP
+.B \-s [<name-prefix>]
+Find/Display ASL operator name(s)
+
+.PP
+.SS ACPI Values
+.TP
+.B \-e [<hex-value>]
+Decode ACPICA exception code
+.TP
+.B \-i
+Display known ACPI Device IDs (_HID)
+.TP
+.B \-i [<hex-value>]
+Decode hex AML opcode
+
+.SH AUTHOR
+acpihelp was written by Robert Moore <robert.moore@intel.com>.
+.PP
+This manual page was written by Al Stone <ahs3@redhat.com> for the
+Fedora project (but may be used by others).

--- a/generate/unix/acpinames/Makefile
+++ b/generate/unix/acpinames/Makefile
@@ -15,6 +15,7 @@
 include ../Makefile.config
 FINAL_PROG = ../$(BINDIR)/acpinames
 PROG = $(OBJDIR)/acpinames
+MAN = acpinames.1
 
 #
 # Search paths for source files

--- a/generate/unix/acpinames/acpinames.1
+++ b/generate/unix/acpinames/acpinames.1
@@ -1,0 +1,49 @@
+.\" First parameter, NAME, should be all caps
+.\" Second parameter, SECTION, should be 1-8, maybe w/ subsection
+.\" other parameters are allowed: see man(7), man(1)
+.TH ACPINAMES 1 "January 23, 2013"
+.\" Please adjust this date whenever revising the manpage.
+.\"
+.\" Some roff macros, for reference:
+.\" .nh        disable hyphenation
+.\" .hy        enable hyphenation
+.\" .ad l      left justify
+.\" .ad b      justify to both left and right margins
+.\" .nf        disable filling
+.\" .fi        enable filling
+.\" .br        insert line break
+.\" .sp <n>    insert n+1 empty lines
+.\" for manpage-specific macros, see man(7)
+.SH NAME
+acpinames \- ACPI name space dump utility
+.SH SYNOPSIS
+.B acpinames
+.RI <option> ...
+.RI <aml-file>
+
+.SH DESCRIPTION
+This manual page briefly documents the
+.B acpinames
+command. The option list is taken from the acpinames interactive help.
+.PP
+.\" TeX users may be more comfortable with the \fB<whatever>\fP and
+.\" \fI<whatever>\fP escape sequences to invode bold face and italics, 
+.\" respectively.
+.B acpinames
+prints out the complete ACPI name space for an AML file.
+.PP
+Much more detailed documentation may be found at
+http://www.acpica.org/documentation/.
+
+.SH OPTIONS
+
+.PP
+.TP
+.B \-? [<name-prefix>]
+Display this help message
+
+.SH AUTHOR
+acpinames was written by Robert Moore <robert.moore@intel.com>.
+.PP
+This manual page was written by Al Stone <ahs3@redhat.com> for the
+Fedora project (but may be used by others).

--- a/generate/unix/acpisrc/Makefile
+++ b/generate/unix/acpisrc/Makefile
@@ -13,6 +13,7 @@
 include ../Makefile.config
 FINAL_PROG = ../$(BINDIR)/acpisrc
 PROG = $(OBJDIR)/acpisrc
+MAN = acpisrc.1
 
 #
 # Search path for source files and individual source files

--- a/generate/unix/acpisrc/acpisrc.1
+++ b/generate/unix/acpisrc/acpisrc.1
@@ -1,0 +1,72 @@
+.\" First parameter, NAME, should be all caps
+.\" Second parameter, SECTION, should be 1-8, maybe w/ subsection
+.\" other parameters are allowed: see man(7), man(1)
+.TH ACPISRC 1 "January 23, 2013"
+.\" Please adjust this date whenever revising the manpage.
+.\"
+.\" Some roff macros, for reference:
+.\" .nh        disable hyphenation
+.\" .hy        enable hyphenation
+.\" .ad l      left justify
+.\" .ad b      justify to both left and right margins
+.\" .nf        disable filling
+.\" .fi        enable filling
+.\" .br        insert line break
+.\" .sp <n>    insert n+1 empty lines
+.\" for manpage-specific macros, see man(7)
+.SH NAME
+acpisrc \- ACPICA source code conversion utility
+.SH SYNOPSIS
+.B acpisrc
+.RI [ -c | -l | -u] [-d] [-s] [-v] [-y] <source-dir> <dest-dir>
+.RI <aml-file>
+
+.SH DESCRIPTION
+This manual page briefly documents the
+.B acpisrc
+command. The option list is taken from the acpisrc interactive help.
+.PP
+.\" TeX users may be more comfortable with the \fB<whatever>\fP and
+.\" \fI<whatever>\fP escape sequences to invode bold face and italics, 
+.\" respectively.
+.B acpisrc
+converts the ACPICA into various forms for use with different operating
+systems.
+Source for ACPICA may be obtained from http://www.acpica.org/source/.
+.PP
+Much more detailed documentation may be found at
+http://www.acpica.org/documentation/.
+
+.SH OPTIONS
+
+.PP
+.TP
+.B \-c
+Generate cleaned version of the source
+.TP
+.B \-h
+Insert dual-license header into all module
+.TP
+.B \-l
+Generate Linux version of the source
+.TP
+.B \-u
+Generate custom source translation
+.TP
+.B \-d
+Leave debug statements in code
+.TP
+.B \-s
+Generate source statistics only
+.TP
+.B \-v
+Verbose mode
+.TP
+.B \-y
+Suppress file overwrite prompts
+
+.SH AUTHOR
+acpisrc was written by Robert Moore <robert.moore@intel.com>.
+.PP
+This manual page was written by Al Stone <ahs3@redhat.com> for the
+Fedora project (but may be used by others).

--- a/generate/unix/acpixtract/Makefile
+++ b/generate/unix/acpixtract/Makefile
@@ -13,6 +13,7 @@
 include ../Makefile.config
 FINAL_PROG = ../$(BINDIR)/acpixtract
 PROG = $(OBJDIR)/acpixtract
+MAN = acpixtract.1
 
 #
 # Search paths for source files

--- a/generate/unix/acpixtract/acpixtract.1
+++ b/generate/unix/acpixtract/acpixtract.1
@@ -1,0 +1,60 @@
+.\" First parameter, NAME, should be all caps
+.\" Second parameter, SECTION, should be 1-8, maybe w/ subsection
+.\" other parameters are allowed: see man(7), man(1)
+.TH ACPIXTRACT 1 "January 23, 2013"
+.\" Please adjust this date whenever revising the manpage.
+.\"
+.\" Some roff macros, for reference:
+.\" .nh        disable hyphenation
+.\" .hy        enable hyphenation
+.\" .ad l      left justify
+.\" .ad b      justify to both left and right margins
+.\" .nf        disable filling
+.\" .fi        enable filling
+.\" .br        insert line break
+.\" .sp <n>    insert n+1 empty lines
+.\" for manpage-specific macros, see man(7)
+.SH NAME
+acpixtract \- ACPICA source code conversion utility
+.SH SYNOPSIS
+.B acpixtract
+.RI [ <option> ... ]
+.RI <acpidump-file>
+
+.SH DESCRIPTION
+This manual page briefly documents the
+.B acpixtract
+command. The option list is taken from the acpixtract interactive help.
+.PP
+.\" TeX users may be more comfortable with the \fB<whatever>\fP and
+.\" \fI<whatever>\fP escape sequences to invode bold face and italics, 
+.\" respectively.
+.B acpixtract
+extracts binary ACPI tables from the output of the
+.B acpidump
+command (see the
+.B pm-tools
+package).  A default invocation will extract the DSDT and
+all SSDTs.
+.PP
+Much more detailed documentation may be found at
+http://www.acpica.org/documentation/.
+
+.SH OPTIONS
+
+.PP
+.TP
+.B \-a
+Extract all tables, not just DSDT/SSDT
+.TP
+.B \-l
+List table summaries, do not extract
+.TP
+.B \-s <signature>
+Extract all tables with <signature>
+
+.SH AUTHOR
+acpixtract was written by Robert Moore <robert.moore@intel.com>.
+.PP
+This manual page was written by Al Stone <ahs3@redhat.com> for the
+Fedora project (but may be used by others).

--- a/generate/unix/iasl/Makefile
+++ b/generate/unix/iasl/Makefile
@@ -13,6 +13,7 @@
 include ../Makefile.config
 FINAL_PROG = ../$(BINDIR)/iasl
 PROG = $(OBJDIR)/iasl
+MAN = iasl.1
 
 #
 # Search paths for source files

--- a/generate/unix/iasl/iasl.1
+++ b/generate/unix/iasl/iasl.1
@@ -1,0 +1,231 @@
+.\" First parameter, NAME, should be all caps
+.\" Second parameter, SECTION, should be 1-8, maybe w/ subsection
+.\" other parameters are allowed: see man(7), man(1)
+.TH IASL 1 "January 23, 2013"
+.\" Please adjust this date whenever revising the manpage.
+.\"
+.\" Some roff macros, for reference:
+.\" .nh        disable hyphenation
+.\" .hy        enable hyphenation
+.\" .ad l      left justify
+.\" .ad b      justify to both left and right margins
+.\" .nf        disable filling
+.\" .fi        enable filling
+.\" .br        insert line break
+.\" .sp <n>    insert n+1 empty lines
+.\" for manpage-specific macros, see man(7)
+.SH NAME
+iasl \- ACPI Source Language compiler/decompiler
+.SH SYNOPSIS
+.B iasl
+.RI [ <option> ... ]
+.RI <input-file>
+.B ...
+.SH DESCRIPTION
+This manual page briefly documents the
+.B iasl
+command. The option list is taken from the iasl interactive help.
+.PP
+.\" TeX users may be more comfortable with the \fB<whatever>\fP and
+.\" \fI<whatever>\fP escape sequences to invode bold face and italics, 
+.\" respectively.
+.B iasl
+is an ASL compiler and decompiler.  This command provides both the ability
+to translate one or more ASL source files to their corresponding AML binary
+files, and the ability to translate AML binary files back to readable
+ASL source.
+.PP
+Much more detailed documentation may be found at
+http://www.acpica.org/documentation/.
+
+.SH OPTIONS
+
+.PP
+.SS Global
+.TP
+.B \-@ <file>
+Specify command file
+.TP
+.B \-I <dir>
+Specify additional include directory
+.TP
+.B \-T <sig>|ALL|*
+Create table template file for ACPI <sig>
+.TP
+.B \-v
+Display compiler version
+
+.PP
+.SS Preprocessor
+.TP
+.B \-D <symbol>
+Define sybol for preprocessor use
+.TP
+.B \-li
+Create prepocessed output file (*.i)
+.TP
+.B \-P
+Preprocess only and create preprocessor output file (*.i)
+.TP
+.B \-Pn
+Disable preprocessor
+
+.PP
+.SS General Output
+.TP
+.B \-p <prefix>
+Specify path/filename prefix for all output files
+.TP
+.B \-va
+Disable all errors and warnings (summary only)
+.TP
+.B \-vi
+Less verbose errors and warnings for use with IDEs
+.TP
+.B \-vo
+Enable optimization comments
+.TP
+.B \-vr
+Disable remarks
+.TP
+.B \-vs
+Disable signon
+.TP
+.B \-w{1|2|3}
+Set warning reporting level
+.TP
+.B \-we
+Report warnings as errors
+
+.PP
+.SS AML and Data Output Files
+.TP
+.B \-s{a|c}
+Create assembler or C source file (*.asm or *.c)
+.TP
+.B \-i{a|c}
+Create assembler or C include file (*.inc or *.h)
+.TP
+.B \-t{a|c|s}
+Create assembler, C, or ASL hex table (*.hex)
+
+.PP
+.SS AML Code Generation
+.TP
+.B \-oa
+Disable all optimizations (compatibility mode)
+.TP
+.B \-of
+Disable constant folding
+.TP
+.B \-oi
+Disable integer optimization to Zero/One/Ones
+.TP
+.B \-on
+Disable named reference string optimization
+.TP
+.B \-cr
+Disable Resource Descriptor error checking
+.TP
+.B \-in
+Ignore NoOp operators
+.TP
+.B \-r <revision>
+Override table header Revision (1-255)
+
+.PP
+.SS ASL Listing Files
+.TP
+.B \-l
+Create mixed listing file (ASL source and AML) (*.lst)
+.TP
+.B \-ln
+Create namespace file (*.nsp)
+.TP
+.B \-ls
+Create combined source file (expanded includes) (*.src)
+
+.PP
+.SS ACPI Data Tables
+.TP
+.B \-G
+Compile custom table containing generic operators
+.TP
+.B \-vt
+Create verbose templates (full disassembly)
+
+.PP
+.SS AML Disassembler
+.TP
+.B \-d [<file>]
+Disassemble AML to ASL source code file (*.dsl)
+.TP
+.B \-da [<file1>,<file2>]
+Disassemble multiple tables from single namespace
+.TP
+.B \-db
+Do not translate Buffers to Resource Templates
+.TP
+.B \-dc [<file>]
+Disassemble AML and immediately compile it
+.br
+(Obtain DSDT from current system if no input file)
+.TP
+.B \-e [<file1>,<file2>]
+Include ACPI table(s) for external symbol resolution
+.TP
+.B \-g
+Get ACPI tables and write to files (*.dat)
+.TP
+.B \-in
+Ignore NoOp opcodes
+.TP
+.B \-vt
+Dump binary table date in hex format within output file
+
+.PP
+.SS Help
+.TP
+.B \-h
+Additional help and compiler debug options
+.TP
+.B \-hc
+Display operators allowed in constant expressions
+.TP
+.B \-hf
+Display help for output file name generation
+.TP
+.B \-hr
+Display ACPI reserved method names
+.TP
+.B \-ht
+Display currently supported ACPI table names
+
+.PP
+.SS Debug
+.TP
+.B \-b{f|t}
+Create debug file (full or parse tree only) (*.txt)
+.TP
+.B \-f
+Ignore errors, force creation of AML output file(s)
+.TP
+.B \-n
+Parse only, no output generation
+.TP
+.B \-ot
+Display compiles times and statistics
+.TP
+.B \-x <level>
+Set debug level for trace output
+.TP
+.B \-z
+Do not insert new compiler ID for DataTables
+
+.SH AUTHOR
+iasl was written by Robert Moore <robert.moore@intel.com>.
+.PP
+This manual page was written by Mattia Dongili <malattia@debian.org>,
+for the Debian project (but may be used by others).  It was updated for
+the Fedora project by Al Stone <ahs3@redhat.com> (and may also be used
+by others).


### PR DESCRIPTION
For each of the various ACPICA tools, create a Linux man page.

This patch adds the source for each man page, and changes the Makefiles
in order to install them properly.

Signed-off-by: Al Stone <ahs3@ahs3.net>