### PR TITLE
Revert "Fix dangling pointer warning for AcpiUtInitStackPtrTrace"

### DIFF
--- a/source/components/debugger/dbstats.c
+++ b/source/components/debugger/dbstats.c
@@ -647,8 +647,8 @@ AcpiDbDisplayStatistics (
             AcpiGbl_EntryStackPointer, AcpiGbl_LowestStackPointer);
 
         AcpiOsPrintf ("\nSubsystem Stack Usage:\n\n");
-        AcpiOsPrintf ("Entry Stack Pointer          %p\n", ACPI_TO_POINTER(AcpiGbl_EntryStackPointer));
-        AcpiOsPrintf ("Lowest Stack Pointer         %p\n", ACPI_TO_POINTER(AcpiGbl_LowestStackPointer));
+        AcpiOsPrintf ("Entry Stack Pointer          %p\n", AcpiGbl_EntryStackPointer);
+        AcpiOsPrintf ("Lowest Stack Pointer         %p\n", AcpiGbl_LowestStackPointer);
         AcpiOsPrintf ("Stack Use                    %X (%u)\n", Temp, Temp);
         AcpiOsPrintf ("Deepest Procedure Nesting    %u\n", AcpiGbl_DeepestNesting);
 #endif

--- a/source/components/utilities/utdebug.c
+++ b/source/components/utilities/utdebug.c
@@ -185,7 +185,7 @@ AcpiUtInitStackPtrTrace (
     ACPI_SIZE               CurrentSp;
 
 
-    AcpiGbl_EntryStackPointer = ACPI_TO_INTEGER(&CurrentSp);
+    AcpiGbl_EntryStackPointer = &CurrentSp;
 }
 
 
@@ -208,9 +208,9 @@ AcpiUtTrackStackPtr (
     ACPI_SIZE               CurrentSp;
 
 
-    if (ACPI_TO_INTEGER(&CurrentSp) < AcpiGbl_LowestStackPointer)
+    if (&CurrentSp < AcpiGbl_LowestStackPointer)
     {
-        AcpiGbl_LowestStackPointer = ACPI_TO_INTEGER(&CurrentSp);
+        AcpiGbl_LowestStackPointer = &CurrentSp;
     }
 
     if (AcpiGbl_NestingLevel > AcpiGbl_DeepestNesting)

--- a/source/components/utilities/utinit.c
+++ b/source/components/utilities/utinit.c
@@ -359,7 +359,7 @@ AcpiUtInitGlobals (
 #endif
 
 #ifdef ACPI_DEBUG_OUTPUT
-    AcpiGbl_LowestStackPointer          = ACPI_SIZE_MAX;
+    AcpiGbl_LowestStackPointer          = ACPI_CAST_PTR (ACPI_SIZE, ACPI_SIZE_MAX);
 #endif
 
 #ifdef ACPI_DBG_TRACK_ALLOCATIONS

--- a/source/include/acglobal.h
+++ b/source/include/acglobal.h
@@ -332,8 +332,8 @@ extern const ACPI_PREDEFINED_NAMES      AcpiGbl_PreDefinedNames [NUM_PREDEFINED_
 ACPI_GLOBAL (UINT32,                    AcpiGbl_CurrentNodeCount);
 ACPI_GLOBAL (UINT32,                    AcpiGbl_CurrentNodeSize);
 ACPI_GLOBAL (UINT32,                    AcpiGbl_MaxConcurrentNodeCount);
-ACPI_GLOBAL (ACPI_UINTPTR_T,            AcpiGbl_EntryStackPointer);
-ACPI_GLOBAL (ACPI_UINTPTR_T,            AcpiGbl_LowestStackPointer);
+ACPI_GLOBAL (ACPI_SIZE *,               AcpiGbl_EntryStackPointer);
+ACPI_GLOBAL (ACPI_SIZE *,               AcpiGbl_LowestStackPointer);
 ACPI_GLOBAL (UINT32,                    AcpiGbl_DeepestNesting);
 ACPI_INIT_GLOBAL (UINT32,               AcpiGbl_NestingLevel, 0);
 #endif

--- a/source/include/actypes.h
+++ b/source/include/actypes.h
@@ -649,7 +649,7 @@ typedef UINT64                          ACPI_INTEGER;
 
 /* Pointer manipulation */
 
-#define ACPI_CAST_PTR(t, p)             ((t *) (ACPI_UINTPTR_T) (void *) (p))
+#define ACPI_CAST_PTR(t, p)             ((t *) (ACPI_UINTPTR_T) (p))
 #define ACPI_CAST_INDIRECT_PTR(t, p)    ((t **) (ACPI_UINTPTR_T) (p))
 #define ACPI_ADD_PTR(t, a, b)           ACPI_CAST_PTR (t, (ACPI_CAST_PTR (UINT8, (a)) + (ACPI_SIZE)(b)))
 #define ACPI_SUB_PTR(t, a, b)           ACPI_CAST_PTR (t, (ACPI_CAST_PTR (UINT8, (a)) - (ACPI_SIZE)(b)))

--- a/source/include/platform/aclinux.h
+++ b/source/include/platform/aclinux.h
@@ -168,8 +168,6 @@
 #define ACPI_USE_DO_WHILE_0
 #define ACPI_IGNORE_PACKAGE_RESOLUTION_ERRORS
 
-#define ACPI_UINTPTR_T uintptr_t
-
 
 #ifdef __KERNEL__
 
@@ -254,6 +252,8 @@
 #define ACPI_SPINLOCK               spinlock_t *
 #define ACPI_CPU_FLAGS              unsigned long
 
+#define ACPI_UINTPTR_T              uintptr_t
+
 #define ACPI_TO_INTEGER(p)          ((uintptr_t)(p))
 #define ACPI_OFFSET(d, f)           offsetof(d, f)
 
@@ -311,7 +311,6 @@
 
 #ifdef ACPI_USE_STANDARD_HEADERS
 #include <unistd.h>
-#include <stdint.h>
 #endif
 
 /* Define/disable kernel-specific declarators */


### PR DESCRIPTION
Reverts acpica/acpica#776

Causes a build errors;

../../../source/components/utilities/utdebug.c: In function ‘AcpiUtInitStackPtrTrace’:
../../../source/components/utilities/utdebug.c:188:31: error: assignment makes pointer from integer without a cast [-Werror=int-conversion]

