### PR TITLE
Fix PCC OperationRegion command offsets

### DIFF
--- a/source/components/executer/exfield.c
+++ b/source/components/executer/exfield.c
@@ -191,12 +191,13 @@ static const UINT8      AcpiProtocolLengths[] =
 
 /*
  * The following macros determine a given offset is a COMD field.
- * According to the specification, generic subspaces (types 0-2) contains a
- * 2-byte COMD field at offset 4 and master subspaces (type 3) contains a 4-byte
- * COMD field starting at offset 12.
+ * According to the specification, the PCC OperationRegion begins after
+ * the PCC signature. The raw shared memory COMD offsets of 4 for generic
+ * subspaces (types 0-2) and 12 for master subspaces (type 3) therefore
+ * appear at OperationRegion offsets 0 and 8.
  */
-#define GENERIC_SUBSPACE_COMMAND(a)     (4 == a || a == 5)
-#define MASTER_SUBSPACE_COMMAND(a)      (12 <= a && a <= 15)
+#define GENERIC_SUBSPACE_COMMAND(a)     ((a) < 2)
+#define MASTER_SUBSPACE_COMMAND(a)      (((a) - 8) < 4)
 
 
 /*******************************************************************************

--- a/source/components/executer/exfield.c
+++ b/source/components/executer/exfield.c
@@ -53,13 +53,13 @@ static const UINT8      AcpiProtocolLengths[] =
 
 /*
  * The following macros determine a given offset is a COMD field.
- * According to the specification, generic subspaces (types 0-2) contains a
- * 2-byte COMD field at offset 4 and master subspaces (type 3) contains a 4-byte
- * COMD field starting at offset 12.
+ * According to the specification, the PCC OperationRegion begins after
+ * the PCC signature. The raw shared memory COMD offsets of 4 for generic
+ * subspaces (types 0-2) and 12 for master subspaces (type 3) therefore
+ * appear at OperationRegion offsets 0 and 8.
  */
-#define GENERIC_SUBSPACE_COMMAND(a)     (4 == a || a == 5)
-#define MASTER_SUBSPACE_COMMAND(a)      (12 <= a && a <= 15)
-
+#define GENERIC_SUBSPACE_COMMAND(a)     (0 == a || a == 1)
+#define MASTER_SUBSPACE_COMMAND(a)      (8 <= a && a <= 11)
 
 /*******************************************************************************
  *


### PR DESCRIPTION
ACPI 6.3, section 5.5.2.4.7.3, states that the PCC Operation Region is associated with the region of shared memory that follows the PCC signature.

The generic and extended PCC shared memory layouts include the 4-byte signature at offset 0, so their raw shared memory COMMAND fields are at offsets 4 and 12 respectively. Since AML field offsets for the PCC OperationRegion are relative to the region after that signature, ACPICA must look for those COMMAND fields at OperationRegion offsets 0 and 8.

Adjust the generic and master subspace command checks to use those OperationRegion-relative offsets. Otherwise writes to the COMMAND field can fail to invoke the PCC address space handler at the offset described by the PCC OperationRegion definition.

Fixes: a4849944e80f ("ACPI 6.3: add PCC operation region support for AML interpreter")