### PR TITLE
Namespace: Initialize ParserState.AmlEnd in AcpiInstallMethod

### DIFF
--- a/source/components/namespace/nsxfname.c
+++ b/source/components/namespace/nsxfname.c
@@ -700,6 +700,7 @@ AcpiInstallMethod (
     /* First AML opcode in the table must be a control method */
 
     ParserState.Aml = Buffer + sizeof (ACPI_TABLE_HEADER);
+    ParserState.AmlEnd = Buffer + Table->Length;
     Opcode = AcpiPsPeekOpcode (&ParserState);
     if (Opcode != AML_METHOD_OP)
     {


### PR DESCRIPTION
In AcpiInstallMethod(), the local ParserState is stack-allocated and only ParserState.Aml was initialized. Parser helpers called by this path read ParserState.AmlEnd for bounds checking: AcpiPsPeekOpcode() reads it before validating the first AML opcode, and AcpiPsGetNextPackageEnd() reads it indirectly via AcpiPsGetNextPackageLength(). The subsequent package-limit check also compares against ParserState.AmlEnd. Because AmlEnd was never set, these checks operated on an uninitialized value, which Coverity flagged as an uninitialized read (CID 1684785) and which could lead to incorrect parser bounds decisions.

Coverity report:

*** CID 1684785:         Memory - illegal accesses  (UNINIT)
/src/acpica/source/components/namespace/nsxfname.c: 712             in AcpiInstallMethod()
        ParserState.Aml += AcpiPsGetOpcodeSize (Opcode);
>>>     CID 1684785:         Memory - illegal accesses  (UNINIT)
>>>     Using uninitialized value "ParserState.AmlEnd" when calling "AcpiPsGetNextPackageEnd".
        ParserState.PkgEnd = AcpiPsGetNextPackageEnd (&ParserState);

Initialize ParserState.AmlEnd to the end of the table (Buffer + Table->Length) so the parser bounds checks operate on a valid limit.