### PR TITLE
iASL: DTPR: Fix dead code in DTPR buffer NULL check

### DIFF
--- a/source/compiler/dttable1.c
+++ b/source/compiler/dttable1.c
@@ -1771,14 +1771,14 @@ DtCompileDtpr (
 
     DtInsertSubtable (ParentTable, Subtable);
 
-    Dtpr = ACPI_SUB_PTR (ACPI_TABLE_DTPR, Subtable->Buffer,
-                         sizeof (ACPI_TABLE_HEADER));
-    if (!Dtpr)
+    if (!Subtable->Buffer)
     {
         AcpiOsPrintf ("DTPR buffer pointer is NULL\n");
         return (AE_NULL_OBJECT);
     }
 
+    Dtpr = ACPI_SUB_PTR (ACPI_TABLE_DTPR, Subtable->Buffer,
+                         sizeof (ACPI_TABLE_HEADER));
     InsCnt = Dtpr->InsCnt;
 
     while (*PFieldList)


### PR DESCRIPTION
Commit bdec5b61c ("Verify DTPR and TPR Instance buffer pointers and refactor comments") added a NULL check on the result of ACPI_SUB_PTR() in DtCompileDtpr():

    Dtpr = ACPI_SUB_PTR (ACPI_TABLE_DTPR, Subtable->Buffer,
                         sizeof (ACPI_TABLE_HEADER));
    if (!Dtpr)
    ...

ACPI_SUB_PTR() is plain pointer arithmetic (Subtable->Buffer minus an offset), so its result can never be NULL. Coverity correctly reports the guard body as unreachable dead code (CID 1684784). The check is also ineffective for its intended purpose: if Subtable->Buffer were NULL, subtracting an offset would yield a non-NULL (wrapped) pointer, so the real NULL buffer condition would slip through.

Coverity report:

*** CID 1684784:         Control flow issues  (DEADCODE)
/src/acpica/source/compiler/dttable1.c: 1768             in DtCompileDtpr()
             if (!Dtpr)
             {
>>>     CID 1684784:         Control flow issues  (DEADCODE)
>>>     Execution cannot reach this statement: "AcpiOsPrintf("DTPR buffer p...".
                 AcpiOsPrintf ("DTPR buffer pointer is NULL\n");

Validate Subtable->Buffer directly before computing Dtpr so the guard is both reachable and meaningful.