### PR TITLE
dispatcher: Allocate the PCC internal buffer only once per region

### DIFF
--- a/source/components/dispatcher/dsfield.c
+++ b/source/components/dispatcher/dsfield.c
@@ -699,7 +699,8 @@ AcpiDsCreateField (
         return_ACPI_STATUS (Status);
     }
 
-    if (Info.RegionNode->Object->Region.SpaceId == ACPI_ADR_SPACE_PLATFORM_COMM)
+    if (Info.RegionNode->Object->Region.SpaceId == ACPI_ADR_SPACE_PLATFORM_COMM &&
+        !RegionNode->Object->Field.InternalPccBuffer)
     {
         RegionNode->Object->Field.InternalPccBuffer =
             ACPI_ALLOCATE_ZEROED(Info.RegionNode->Object->Region.Length);


### PR DESCRIPTION
AcpiDsCreateField() allocates InternalPccBuffer for operation regions in the PCC address space. It runs once per Field() operator, so a second Field() naming the same region overwrites the pointer and orphans the buffer the first one allocated. The matching ACPI_FREE() in AcpiUtDeleteInternalObj() only ever sees the last one.

Every field unit of a PCC region reads and writes through RegionObj->Field.InternalPccBuffer, so one buffer per region is enough. Skip the allocation when the region object already has one.

Reproduced with a table declaring two Field() operators on one PCC region. Before, acpiexec reports the orphaned buffer at exit:

  0x4a09b0 Length 0x00C0   dsfield-0705 [Not a Descriptor]
  ACPI Error: 5 (0x5) Outstanding cache allocations

After, that allocation is gone and field access is unchanged.

On linux, this is detected by kmemleak, as shown in https://lore.kernel.org/all/20260813-acpica-pcc-field-leak-v1-1-3d6c5f0eb557@debian.org/