### PR TITLE
Add the _Ixx object

### DIFF
--- a/source/common/ahpredef.c
+++ b/source/common/ahpredef.c
@@ -149,6 +149,7 @@ const AH_PREDEFINED_NAME    AslPredefinedInfo[] =
     AH_PREDEF ("_INT",    "Interrupts", "Interrupt mask bits, Resource Descriptor field"),
     AH_PREDEF ("_IOR",    "I/O Restriction", "Restriction type, Resource Descriptor field"),
     AH_PREDEF ("_IRC",    "Inrush Current", "Presence indicates that a device has a significant inrush current draw"),
+    AH_PREDEF ("_Ixx",    "Low Power S0 Idle, xx=0x00-0xFF", "Indication whether specific GPEs should be enabled in low power S0 idle state."),
     AH_PREDEF ("_Lxx",    "Level-Triggered GPE, xx=0x00-0xFF", "Control method executed as a result of a general-purpose event"),
     AH_PREDEF ("_LCK",    "Lock Device", "Locks or unlocks a device (docking)"),
     AH_PREDEF ("_LEN",    "Length", "Range length, Resource Descriptor field"),

--- a/source/compiler/asldefine.h
+++ b/source/compiler/asldefine.h
@@ -104,6 +104,7 @@
 #define ACPI_PREDEFINED_NAME            (ACPI_UINT32_MAX - 1)
 #define ACPI_EVENT_RESERVED_NAME        (ACPI_UINT32_MAX - 2)
 #define ACPI_COMPILER_RESERVED_NAME     (ACPI_UINT32_MAX - 3)
+#define ACPI_EVENT_OBJECT_RESERVED_NAME (ACPI_UINT32_MAX - 4)
 
 
 /* Helper macros for resource tag creation */

--- a/source/compiler/aslpredef.c
+++ b/source/compiler/aslpredef.c
@@ -76,11 +76,12 @@ ApCheckForPredefinedMethod (
         return (FALSE);
 
 
-    case ACPI_EVENT_RESERVED_NAME:      /* _Lxx/_Exx/_Wxx/_Qxx methods */
+    case ACPI_EVENT_RESERVED_NAME:          /* _Lxx/_Exx/_Wxx/_Qxx methods */
+    case ACPI_EVENT_OBJECT_RESERVED_NAME:   /* _Ixx object */
 
         AslGbl_ReservedMethods++;
 
-        /* NumArguments must be zero for all _Lxx/_Exx/_Wxx/_Qxx methods */
+        /* NumArguments must be zero for all _Lxx/_Exx/_Wxx/_Ixx/_Qxx methods */
 
         if (MethodInfo->NumArguments != 0)
         {
@@ -234,7 +235,8 @@ ApCheckPredefinedReturnValue (
 
     switch (Index)
     {
-    case ACPI_EVENT_RESERVED_NAME:      /* _Lxx/_Exx/_Wxx/_Qxx methods */
+    case ACPI_EVENT_RESERVED_NAME:          /* _Lxx/_Exx/_Wxx/_Qxx methods */
+    case ACPI_EVENT_OBJECT_RESERVED_NAME:   /* _Ixx object */
 
         /* No return value expected, warn if there is one */
 
@@ -335,9 +337,10 @@ ApCheckForPredefinedObject (
 
     switch (Index)
     {
-    case ACPI_NOT_RESERVED_NAME:        /* No underscore or _Txx or _xxx name not matched */
-    case ACPI_PREDEFINED_NAME:          /* Resource Name or reserved scope name */
-    case ACPI_COMPILER_RESERVED_NAME:   /* A _Txx that was not emitted by compiler */
+    case ACPI_NOT_RESERVED_NAME:            /* No underscore or _Txx or _xxx name not matched */
+    case ACPI_PREDEFINED_NAME:              /* Resource Name or reserved scope name */
+    case ACPI_COMPILER_RESERVED_NAME:       /* A _Txx that was not emitted by compiler */
+    case ACPI_EVENT_OBJECT_RESERVED_NAME:   /* _Ixx object */
 
         /* Nothing to do */
         return;
@@ -473,7 +476,7 @@ ApCheckForPredefinedName (
         ThisName++;
     }
 
-    /* Check for _Lxx/_Exx/_Wxx/_Qxx/_T_x. Warning if unknown predefined name */
+    /* Check for _Lxx/_Exx/_Wxx/_Ixx/_Qxx/_T_x. Warning if unknown predefined name */
 
     return (ApCheckForSpecialName (Op, Name));
 }
@@ -489,7 +492,7 @@ ApCheckForPredefinedName (
  * RETURN:      None
  *
  * DESCRIPTION: Check for the "special" predefined names -
- *              _Lxx, _Exx, _Qxx, _Wxx, and _T_x
+ *              _Lxx, _Exx, _Qxx, _Ixx, _Wxx, and _T_x
  *
  ******************************************************************************/
 
@@ -505,6 +508,7 @@ ApCheckForSpecialName (
      *   GPE:  _Lxx
      *   GPE:  _Exx
      *   GPE:  _Wxx
+     *   GPE:  _Ixx
      *   EC:   _Qxx
      */
     if ((Name[1] == 'L') ||
@@ -519,6 +523,18 @@ ApCheckForSpecialName (
         {
             return (ACPI_EVENT_RESERVED_NAME);
         }
+    }
+
+    /*
+     * Return an object reserved name type since _Ixx is just required to be an
+     * 'object' not necessarily a control method to indicate that a GPE is to be
+     * enabled in LPS0 idle state
+     */
+    else if ((Name[1] == 'I') &&
+        ((isxdigit ((int) Name[2])) &&
+        (isxdigit ((int) Name[3]))))
+    {
+        return (ACPI_EVENT_OBJECT_RESERVED_NAME);
     }
 
     /* Check for the names reserved for the compiler itself: _T_x */

--- a/source/components/disassembler/dmopcode.c
+++ b/source/components/disassembler/dmopcode.c
@@ -239,7 +239,7 @@ AcpiDmPredefinedDescription (
 
     /*
      * Check for the special ACPI names:
-     * _ACd, _ALd, _EJd, _Exx, _Lxx, _Qxx, _Wxx, _T_a
+     * _ACd, _ALd, _EJd, _Exx, _Lxx, _Qxx, _Wxx, _Ixx, _T_a
      * (where d=decimal_digit, x=hex_digit, a=anything)
      *
      * Convert these to the generic name for table lookup.
@@ -274,6 +274,14 @@ AcpiDmPredefinedDescription (
         else if (LastCharsAreHex)
         {
             NameString = "_Exx";
+        }
+        break;
+
+    case 'I':
+
+        if (LastCharsAreHex)
+        {
+            NameString = "_Ixx";
         }
         break;
 

--- a/source/include/acpredef.h
+++ b/source/include/acpredef.h
@@ -161,6 +161,7 @@ enum AcpiReturnPackageTypes
  *              _Qxx EC methods
  *              _T_x compiler temporary variables
  *              _Wxx wake events
+ *              _Ixx indicator for GPEs in low power S0 idle state
  *
  *      2) Predefined names that never actually exist within the AML code:
  *              Predefined resource descriptor field names

--- a/source/tools/acpihelp/ahdecode.c
+++ b/source/tools/acpihelp/ahdecode.c
@@ -217,6 +217,7 @@ AhFindPredefinedNames (
  *  _Exx
  *  _Lxx
  *  _Qxx
+ *  _Ixx
  *  _Wxx
  *  _ACx
  *  _ALx
@@ -253,11 +254,12 @@ AhDoSpecialNames (
     case 'L':
     case 'Q':
     case 'W':
+    case 'I':
         if ((isxdigit ((int) Name[2]) && isxdigit ((int) Name[3]))
                 ||
             ((Name[2] == 'X') && (Name[3] == 'X')))
         {
-            /* _Exx, _Lxx, _Qxx, or _Wxx */
+            /* _Exx, _Lxx, _Qxx, _Ixx or _Wxx */
 
             Name[2] = 'x';
             Name[3] = 'x';


### PR DESCRIPTION
ACPI 6.6 specification, chapter 5.6.4.3 mentions an _Ixx object (where
xx is a two-digit hexadecimal number) which presence indicates that the
corresponding GPE is enabled in the low power S0 idle state.

Add a new reserved name type to symbolize an object. Since the
specification mentions that just the presence of the object is required,
any one of Name(), Method(), Device(), etc. with the _Ixx name should be
a valid indication.

Update comments and the disassembler path.
