### PR TITLE
Follow up memory safety fixes

### DIFF
--- a/source/compiler/dttable2.c
+++ b/source/compiler/dttable2.c
@@ -1576,30 +1576,34 @@ DtCompilePptt (
         {
         case ACPI_PPTT_TYPE_PROCESSOR:
 
+            if (!Subtable->Buffer)
+            {
+                AcpiOsPrintf ("Pptt subtable buffer pointer is NULL\n");
+                return (AE_NULL_OBJECT);
+            }
+
             PpttProcessor = ACPI_SUB_PTR (ACPI_PPTT_PROCESSOR,
                 Subtable->Buffer, sizeof (ACPI_SUBTABLE_HEADER));
-            if (PpttProcessor)
+
+            /* Compile initiator proximity domain list */
+
+            PpttProcessor->NumberOfPrivResources = 0;
+            while (*PFieldList)
             {
-                /* Compile initiator proximity domain list */
-
-                PpttProcessor->NumberOfPrivResources = 0;
-                while (*PFieldList)
+                Status = DtCompileTable (PFieldList,
+                    AcpiDmTableInfoPptt0a, &Subtable);
+                if (ACPI_FAILURE (Status))
                 {
-                    Status = DtCompileTable (PFieldList,
-                        AcpiDmTableInfoPptt0a, &Subtable);
-                    if (ACPI_FAILURE (Status))
-                    {
-                        return (Status);
-                    }
-                    if (!Subtable)
-                    {
-                        break;
-                    }
-
-                    DtInsertSubtable (ParentTable, Subtable);
-                    PpttHeader->Length += (UINT8)(Subtable->Length);
-                    PpttProcessor->NumberOfPrivResources++;
+                    return (Status);
                 }
+                if (!Subtable)
+                {
+                    break;
+                }
+
+                DtInsertSubtable (ParentTable, Subtable);
+                PpttHeader->Length += (UINT8)(Subtable->Length);
+                PpttProcessor->NumberOfPrivResources++;
             }
             break;
         default:

--- a/source/components/namespace/nsxfname.c
+++ b/source/components/namespace/nsxfname.c
@@ -579,6 +579,15 @@ AcpiInstallMethod (
     }
     Path = AcpiPsGetNextNamestring (&ParserState);
 
+    /*
+     * Path can be NULL, and Aml can be PkgEnd which combined with the Aml++
+     * a few lines below will cause AmlLength to underflow.
+     */
+    if (!Path || (ParserState.Aml >= ParserState.PkgEnd))
+    {
+        return (AE_AML_PACKAGE_LIMIT);
+    }
+
     MethodFlags = *ParserState.Aml++;
     AmlStart = ParserState.Aml;
     AmlLength = (UINT32) ACPI_PTR_DIFF (ParserState.PkgEnd, AmlStart);


### PR DESCRIPTION
Pull requests #1216 and #1217 provided some very good memory safety fixes.
While checking them out I noticed more similar problems in direct vicinity of
where these two PRs made changes. More detailed description of both problems are
located in the patch messages.
