### PR TITLE
Respect OSDT overrides in acpi_ns_execute_table()

### DIFF
--- a/source/components/dispatcher/dswload2.c
+++ b/source/components/dispatcher/dswload2.c
@@ -287,7 +287,14 @@ AcpiDsLoad2BeginOp (
         {
             /* Execution mode, node cannot already exist, node is temporary */
 
-            Flags |= ACPI_NS_ERROR_IF_FOUND;
+            if (WalkState->NamespaceOverride)
+            {
+                Flags |= ACPI_NS_OVERRIDE_IF_FOUND;
+            }
+            else
+            {
+                Flags |= ACPI_NS_ERROR_IF_FOUND;
+            }
 
             if (!(WalkState->ParseFlags & ACPI_PARSE_MODULE_LEVEL))
             {

--- a/source/components/namespace/nsparse.c
+++ b/source/components/namespace/nsparse.c
@@ -103,6 +103,12 @@ AcpiNsExecuteTable (
         goto Cleanup;
     }
 
+    if (ACPI_COMPARE_NAMESEG(Table->Signature, ACPI_SIG_OSDT))
+    {
+        Info->Flags |= ACPI_NAMESPACE_OVERRIDE;
+    }
+
+
     ACPI_DEBUG_PRINT_RAW ((ACPI_DB_PARSE,
         "%s: Create table pseudo-method for [%4.4s] @%p, method %p\n",
         ACPI_GET_FUNCTION_NAME, Table->Signature, Table, MethodObj));

--- a/source/components/parser/psxface.c
+++ b/source/components/parser/psxface.c
@@ -294,6 +294,10 @@ AcpiPsExecuteTable (
         goto Cleanup;
     }
 
+	if (Info->Flags & ACPI_NAMESPACE_OVERRIDE) {
+		WalkState->NamespaceOverride = TRUE;
+	}
+
     Status = AcpiDsInitAmlWalk (WalkState, Op, Info->Node,
         Info->ObjDesc->Method.AmlStart,
         Info->ObjDesc->Method.AmlLength, Info, Info->PassNumber);

--- a/source/include/acstruct.h
+++ b/source/include/acstruct.h
@@ -199,6 +199,7 @@ typedef struct acpi_evaluate_info
 /* Values for Flags above */
 
 #define ACPI_IGNORE_RETURN_VALUE    1
+#define ACPI_NAMESPACE_OVERRIDE     2
 
 /* Defines for ReturnFlags field above */
 


### PR DESCRIPTION
Currently there is only partial support for OSDT tables (which should override already-defined methods) -- it works when tables are loaded via `AcpiNsOneCompleteParse()`, but not for `AcpiNsParseTable()`, which is what's actually used in e.g. `acpiexec` or the Linux kernel. This PR remedies that by adding support.