### PR TITLE
namespace: Initialize remaining parser state in AcpiInstallMethod

### DIFF
--- a/source/components/namespace/nsxfname.c
+++ b/source/components/namespace/nsxfname.c
@@ -559,9 +559,11 @@ AcpiInstallMethod (
         return (AE_BAD_HEADER);
     }
 
+    ParserState.Aml = ParserState.AmlStart = Buffer + sizeof (ACPI_TABLE_HEADER);
+    ParserState.AmlEnd = Buffer + Table->Length;
+
     /* First AML opcode in the table must be a control method */
 
-    ParserState.Aml = Buffer + sizeof (ACPI_TABLE_HEADER);
     Opcode = AcpiPsPeekOpcode (&ParserState);
     if (Opcode != AML_METHOD_OP)
     {


### PR DESCRIPTION
AcpiInstallMethod only sets ParserState.Aml and leaves some of the parser state uninitialized at the beginning. As a result, AcpiPsPeekOpcode, AcpiPsGetNextPackageLength, and AcpiPsGetNextNamestring all perform bounds checks against an uninitialized ParserState.AmlEnd value. The same applies to the PkgEnd validation in AcpiInstallMethod, which also reads uninitialized stack data.

Set AmlStart and AmlEnd from the table header before the parser helpers are called. A table with no AML past the header needs no separate check: Aml then equals AmlEnd and the existing opcode check rejects it.