### PR TITLE
ACPICA: Add ACPI_MSG_DEBUG to set KERN_DEBUG for debug output

### DIFF
--- a/source/components/utilities/utdebug.c
+++ b/source/components/utilities/utdebug.c
@@ -182,6 +182,7 @@ AcpiDebugPrint (
         if (ACPI_LV_THREADS & AcpiDbgLevel)
         {
             AcpiOsPrintf (
+                ACPI_MSG_DEBUG
                 "\n**** Context Switch from TID %u to TID %u ****\n\n",
                 (UINT32) AcpiGbl_PreviousThreadId, (UINT32) ThreadId);
         }
@@ -194,7 +195,7 @@ AcpiDebugPrint (
      * Display the module name, current line number, thread ID (if requested),
      * current procedure nesting level, and the current procedure name
      */
-    AcpiOsPrintf ("%9s-%04d ", ModuleName, LineNumber);
+    AcpiOsPrintf (ACPI_MSG_DEBUG "%9s-%04d ", ModuleName, LineNumber);
 
 #ifdef ACPI_APPLICATION
     /*

--- a/source/include/acutils.h
+++ b/source/include/acutils.h
@@ -105,6 +105,9 @@ extern const char                       *AcpiGbl_ClockInputScale[];
 #ifndef ACPI_MSG_BIOS_WARNING
 #define ACPI_MSG_BIOS_WARNING   "Firmware Warning (ACPI): "
 #endif
+#ifndef ACPI_MSG_DEBUG
+#define ACPI_MSG_DEBUG          ""
+#endif
 
 /*
  * Common message suffix

--- a/source/include/platform/aclinux.h
+++ b/source/include/platform/aclinux.h
@@ -161,6 +161,7 @@
 
 #define ACPI_MSG_BIOS_ERROR     KERN_ERR "ACPI BIOS Error (bug): "
 #define ACPI_MSG_BIOS_WARNING   KERN_WARNING "ACPI BIOS Warning (bug): "
+#define ACPI_MSG_DEBUG          KERN_DEBUG
 
 /*
  * Linux wants to use designated initializers for function pointer structs.


### PR DESCRIPTION
acpi_debug_print() emits ACPI debug output using multi-part acpi_os_printf() and acpi_os_vprintf() calls without any loglevel prefix.

When acpi_os_vprintf() processes a chunk without a loglevel prefix (printk_get_level() returns 0), it prepends KERN_CONT. Because the initial header chunk lacks a loglevel prefix, it either attaches to a preceding unfinalized log message (inheriting its level) or, when split across printk buffer records, falls back to the default message loglevel rather than KERN_DEBUG. This can cause dmesg to misinterpret and colorize debug messages as errors.

Define ACPI_MSG_DEBUG as KERN_DEBUG in aclinux.h (with an empty fallback in acutils.h for ACPICA OS-independence) and prefix debug message headers and context switch output in acpi_debug_print() with ACPI_MSG_DEBUG so that printk records are properly tagged with KERN_DEBUG.